### PR TITLE
Fixes options not being added at init and non-matching option names

### DIFF
--- a/ell_box.inx
+++ b/ell_box.inx
@@ -24,8 +24,8 @@
 	<param name="cut_nr" type="int" min="1" max="100" _gui-text="Number of cuts">3</param>
 	<param name="lid_angle" type="float" min="0.0" max="360.0" _gui-text="Lid angle">120</param>
 	<param name="invert_lid_notches" type="boolean" _gui-text="Invert lid notch pattern (this will create a lid without sideways support)">false</param>
-	<param name="central_rib_lid" type="boolean" _gui-text="Create central rib in the lid(requires an even number of cuts)">false</param>
-	<param name="central_rib_body" type="boolean" _gui-text="Create central rib in the body(requires an even number of cuts)">false</param>
+	<param name="centralRibLid" type="boolean" _gui-text="Create central rib in the lid(requires an even number of cuts)">false</param>
+	<param name="centralRibBody" type="boolean" _gui-text="Create central rib in the body(requires an even number of cuts)">false</param>
 	<effect>
 		<object-type>all</object-type>
 		<effects-menu>

--- a/ell_box.py
+++ b/ell_box.py
@@ -119,9 +119,10 @@ class EllipticalBox(doc.Effect):
             ['body_ribcount', 'int', '0', 'Number of ribs in the body'],
             ['lid_ribcount', 'int', '0', 'Number of ribs in the lid'],
             ['invert_lid_notches', 'inkbool', 'false', 'Invert the notch pattern on the lid (keeps the lid from sliding sideways)'],
-            ['central_rib_lid', 'inkbool', 'false', 'Create a central rib in the lid'],
-            ['central_rib_body', 'inkbool', 'false', 'Create a central rib in the body']
+            ['centralRibLid', 'inkbool', 'false', 'Create a central rib in the lid'],
+            ['centralRibBody', 'inkbool', 'false', 'Create a central rib in the body']
         ]
+        doc.Effect.__init__(self, options)
 
 
     def effect(self):


### PR DESCRIPTION
Fixed the error in
https://github.com/BvdP/elliptical-box-maker/issues/3
by executing the init method from the parent class (which was overwritten, and thus not used).

After fixing that, non-matching option names caused a further error.

Works now :)

Could you please merge, @BvdP ?